### PR TITLE
jupyterlab-geojson 3.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "jupyterlab-geojson" %}
-{% set version = "3.3.1" %}
+{% set version = "3.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/jupyterlab/jupyter-renderers/archive/refs/tags/@jupyterlab/geojson-extension@3.3.1.tar.gz
-  sha256: 97d866920866098cd9c53835843a6f444dd5766a8e5e8cb8919b28e9874c7e08
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyterlab-geojson-{{ version }}.tar.gz
+  sha256: 87640df0174f12dea44f1224843704b63fee7dcd1d35565e1dfedd1f7a81b9ee
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
   commands:
     - pip check
     - test -f "${PREFIX}/share/jupyter/labextensions/@jupyterlab/geojson-extension/package.json"                                    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,8 @@ build:
 
 requirements:
   host:
-    - jupyter-packaging 0.7.9
-    - jupyterlab 3.4.4
+    - jupyter-packaging >=0.7.9,<1.0
+    - jupyterlab >=3.0.0,<4.0.0
     - pip
     - python
     - setuptools
@@ -33,8 +33,6 @@ test:
     - pip check
     - test -f "${PREFIX}/share/jupyter/labextensions/@jupyterlab/geojson-extension/package.json"                                    # [unix]
     - if exist %PREFIX%\\share\\jupyter\\labextensions\\@jupyterlab\\geojson-extension\\package.json (exit 0) else (exit 1)         # [win]
-  requires:
-    - pip
 
 about:
   home: https://github.com/jupyterlab/jupyter-renderers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - jupyter-packaging >=0.7.9,<1.0
+    - jupyter-packaging 0.7.9
     - jupyterlab >=3.0.0,<4.0.0
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - jupyter-packaging 0.7.9
-    - jupyterlab >=3.0.0,<4.0.0
+    - jupyterlab 3.4.4
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyterlab-geojson-{{ version }}.tar.gz
-  sha256: 45da6d1df8fedf8edf3fc6bdf58106d99d7b4a982df978342512b37c75393825
+  url: https://github.com/jupyterlab/jupyter-renderers/archive/refs/tags/@jupyterlab/geojson-extension@3.3.1.tar.gz
+  sha256: 97d866920866098cd9c53835843a6f444dd5766a8e5e8cb8919b28e9874c7e08
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "jupyterlab-geojson" %}
 {% set version = "3.3.1" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -12,16 +11,19 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - jupyter-packaging >=0.7.9,<0.8.0
+    - jupyter-packaging >=0.7.9,<1.0
+    - jupyterlab >=3.0.0,<4.0.0
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   commands:
@@ -34,8 +36,13 @@ test:
 about:
   home: https://github.com/jupyterlab/jupyter-renderers
   summary: GeoJSON renderer for JupyterLab
+  description: |
+    This package provides a GeoJSON renderer for JupyterLab.
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
+  dev_url: https://github.com/jupyterlab/jupyter-renderers/tree/master/packages/geojson-extension
+  doc_url: https://github.com/jupyterlab/jupyter-renderers/tree/master/packages/geojson-extension
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,14 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  # jupyterlab is missing on s390x
+  skip: true  # [py<36 or (linux and s390x)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
     - jupyter-packaging 0.7.9
-    - jupyterlab >=3.0.0,<4.0.0
+    - jupyterlab 3.4.4
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - jupyter-packaging 0.7.9
-    - jupyterlab 3.4.4
+    - jupyterlab >=3.0.0,<4.0.0
     - pip
     - python
     - setuptools


### PR DESCRIPTION
License: https://github.com/jupyterlab/jupyter-renderers/blob/%40jupyterlab/geojson-extension%403.3.1/packages/geojson-extension/LICENSE
Requirements:
- https://github.com/jupyterlab/jupyter-renderers/blame/%40jupyterlab/geojson-extension%403.3.1/packages/geojson-extension/pyproject.toml
- https://github.com/jupyterlab/jupyter-renderers/blob/%40jupyterlab/geojson-extension%403.3.1/packages/geojson-extension/setup.py

Actions:
1. Remove noarch
2. Skip py<36
3. Skip s390x
4. Add --no-deps
5. Fix python pinnings
6. Fix jupyter-packaging pinning because the upstream pyproject.toml was created on 5 Mar 2021 and after that date jupyter-packaging released new versions, they are compatible until <1.0
7. Add missing jupyterlab >=3.0.0,<4.0.0, setuptools, wheel to host
8. Add license_family
9. Add description
10. Add dev and doc urls